### PR TITLE
Fix warnings for CLANG_WARN_STRICT_PROTOTYPES

### DIFF
--- a/MBProgressHUD.h
+++ b/MBProgressHUD.h
@@ -85,7 +85,7 @@ typedef enum {
 #endif
 
 #if NS_BLOCKS_AVAILABLE
-typedef void (^MBProgressHUDCompletionBlock)();
+typedef void (^MBProgressHUDCompletionBlock)(void);
 #endif
 
 

--- a/MBProgressHUD.m
+++ b/MBProgressHUD.m
@@ -404,7 +404,7 @@ static const CGFloat kDetailsLabelFontSize = 12.f;
 	[self showAnimated:animated whileExecutingBlock:block onQueue:queue completionBlock:NULL];
 }
 
-- (void)showAnimated:(BOOL)animated whileExecutingBlock:(dispatch_block_t)block completionBlock:(void (^)())completion {
+- (void)showAnimated:(BOOL)animated whileExecutingBlock:(dispatch_block_t)block completionBlock:(void (^)(void))completion {
 	dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	[self showAnimated:animated whileExecutingBlock:block onQueue:queue completionBlock:completion];
 }


### PR DESCRIPTION
This warning is now being enforced as of Xcode 9.3.

The original - jdg/MBProgressHUD - has addressed this but we have diverged substantially from them, so for now I am just adding a quick fix.

Potentially in the future we could submit our improvements to the library as PRs and go back to using the original.